### PR TITLE
added token

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ export default {
 - Replace `plugin:@typescript-eslint/recommended` to `plugin:@typescript-eslint/recommended-type-checked` or `plugin:@typescript-eslint/strict-type-checked`
 - Optionally add `plugin:@typescript-eslint/stylistic-type-checked`
 - Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and add `plugin:react/recommended` & `plugin:react/jsx-runtime` to the `extends` list
+
+# Note to me
+
+If project does not update, invalidate in cloudfront.

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -23,7 +23,9 @@ export const getSignedUrl = async (fileName: string) => {
   const token = btoa(credentials);
 
   const response = await fetch(`${APIS.import}/${fileName}`, {
-    headers: { Authorization: `Basic ${token}` },
+    headers: {
+      Authorization: `Basic ${token}`,
+    },
   });
   if (response.ok) {
     const json = await response.json();

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -19,33 +19,32 @@ export const getProductsById = async (productId: number) => {
 };
 
 export const getSignedUrl = async (fileName: string) => {
-  try {
-    const response = await fetch(`${APIS.import}/${fileName}`);
+  const credentials = localStorage.getItem('authorization_token') ?? '';
+  const token = btoa(credentials);
+
+  const response = await fetch(`${APIS.import}/${fileName}`, {
+    headers: { Authorization: `Basic ${token}` },
+  });
+  if (response.ok) {
     const json = await response.json();
     return json.url;
-  } catch (error) {
-    throw new Error('Error getting signedUrl');
+  } else {
+    throw response;
   }
 };
 
-export const uploadFile = async (payload: {
-  fileName: string;
-  file: File;
-}): Promise<boolean> => {
+export const uploadFile = async (payload: { fileName: string; file: File }) => {
   const signedUrl = await getSignedUrl(payload.fileName);
 
-  try {
-    await fetch(signedUrl, {
-      method: 'PUT',
-      body: payload.file,
-      headers: {
-        'Content-Type': 'text/csv',
-        'Content-Disposition': `attachment; filename="${payload.fileName}"`,
-      },
-    });
-    return true;
-  } catch (error) {
-    console.log('uploadFile', error);
-    return false;
+  const response = await fetch(signedUrl, {
+    method: 'PUT',
+    body: payload.file,
+    headers: {
+      'Content-Type': 'text/csv',
+      'Content-Disposition': `attachment; filename="${payload.fileName}"`,
+    },
+  });
+  if (!response.ok) {
+    throw response;
   }
 };

--- a/src/components/UploadCsv.tsx
+++ b/src/components/UploadCsv.tsx
@@ -14,11 +14,15 @@ export default function UploadCsv() {
         title: 'Products uploaded',
       });
     },
-    onError: (error) => {
-      console.error(error.message);
+    onError: (error: any) => {
+      let description = 'Something went wrong';
+      if (error.status === 401 || error.status === 403) {
+        console.error(error);
+        description = 'Unauthorized';
+      }
       toast({
         title: 'Error!',
-        description: 'Something went wrong',
+        description,
       });
     },
   });

--- a/src/components/UploadCsv.tsx
+++ b/src/components/UploadCsv.tsx
@@ -15,7 +15,7 @@ export default function UploadCsv() {
       });
     },
     onError: (error) => {
-      console.error(error);
+      console.error(error.message);
       toast({
         title: 'Error!',
         description: 'Something went wrong',

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -25,6 +25,10 @@ const router = createBrowserRouter([
       },
     ],
   },
+  {
+    path: '/upload',
+    element: <UploadCsv />,
+  },
 ]);
 
 ReactDOM.createRoot(document.getElementById('root')!).render(


### PR DESCRIPTION
## Tasks
- [x] Task 7.1
- [x] Task 7.2
- [x] Task 7.3
- [x] Task 7.4
- [x] +30 - Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the nodejs-aws-fe-main/src/index.tsx file.
<img width="781" alt="image" src="https://github.com/erickv99/serverless-frontend/assets/161263294/3926d8a9-b634-4432-a16f-8961daa6ce2c">



## Frontend link

https://d1gsz2pixpaq08.cloudfront.net/


## Credentials
```
localStorage.setItem('authorization_token','erickv99:TEST_PASSWORD')
```